### PR TITLE
feat-AddedAPIStuff

### DIFF
--- a/backend/src/data/DataProcessor.py
+++ b/backend/src/data/DataProcessor.py
@@ -1,0 +1,15 @@
+import json
+
+import pandas as pd
+import matplotlib.pyplot as plt
+
+kaggle_df = pd.read_csv('raw/kaggle.csv')
+
+# print(type(kaggle_df[["track_id"]]), kaggle_df.columns)
+
+json_data = kaggle_df[["track_id"]].to_dict(orient='records')
+print(json_data)
+
+# with open('../../../frontend/public/songs_data.json', 'w') as json_file:
+#     json.dump(json_data, json_file, indent=4)
+

--- a/backend/src/data/raw/release_dates_0_104.json
+++ b/backend/src/data/raw/release_dates_0_104.json
@@ -1,0 +1,422 @@
+[
+  {
+    "track_id": "0U32q8CZRRo7xCzyiaZw5f",
+    "release_date": "2013-05-29"
+  },
+  {
+    "track_id": "5p9XWUdvbUzmPCukOmwoU3",
+    "release_date": "2005-01-01"
+  },
+  {
+    "track_id": "7DYsBLdOqz0z14tYWMt2Tn",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "6ivkBaxvclVhwZDE2uwldj",
+    "release_date": "2010-04-06"
+  },
+  {
+    "track_id": "78TKtlSLWK8pZAKKW3MyQL",
+    "release_date": "2013-11-04"
+  },
+  {
+    "track_id": "4kQXMVjoZ9yMibLZq5Aqi5",
+    "release_date": "2020-03-20"
+  },
+  {
+    "track_id": "2RFt6ZWQbr9mPhsft9u9eX",
+    "release_date": "2020-01-17"
+  },
+  {
+    "track_id": "1pG5nd6gmfbMwUfT5shDQe",
+    "release_date": "2018-12-21"
+  },
+  {
+    "track_id": "1PR5pyPiOEEQ02oJYq402x",
+    "release_date": "2015-04-28"
+  },
+  {
+    "track_id": "5OGpsZeJRZ3t3MZioawcZW",
+    "release_date": "2022-10-20"
+  },
+  {
+    "track_id": "2WD93lsfJonaKtrQtpLB2R",
+    "release_date": "2021-08-20"
+  },
+  {
+    "track_id": "7ACW42whcdOiUxiNVu7ltx",
+    "release_date": "2020-11-20"
+  },
+  {
+    "track_id": "5O9R57EozcpLKGQBzadPVy",
+    "release_date": "2021-01-24"
+  },
+  {
+    "track_id": "5ZetMq21bMQN5oo4TtdOxu",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "2D9w6sabdMCLSheW5aegwO",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "6R6ux6KaKrhAg2EIB2krdU",
+    "release_date": "2016-01-15"
+  },
+  {
+    "track_id": "23Mcmg5O8rBKAOzxvrTjnD",
+    "release_date": "2021-11-17"
+  },
+  {
+    "track_id": "1WFVfVjCtbmdIv7j3Fa9iy",
+    "release_date": "2022-10-07"
+  },
+  {
+    "track_id": "5RO0MNa5hBKIM4OcjygadU",
+    "release_date": "2022-07-29"
+  },
+  {
+    "track_id": "2qESE1ZeWly7I3YjyTXmXh",
+    "release_date": "2022-10-07"
+  },
+  {
+    "track_id": "0JvkNRyq8Tmot9khpdtN0I",
+    "release_date": "2022-10-07"
+  },
+  {
+    "track_id": "08OjvLnGR3M0HUhcePeMNO",
+    "release_date": "2020-05-07"
+  },
+  {
+    "track_id": "7d0bJhpp0mCYyMXaMgWyMS",
+    "release_date": "2018-10-08"
+  },
+  {
+    "track_id": "6IF2P93LkyW4GqDQu1yS7H",
+    "release_date": "2014-05-19"
+  },
+  {
+    "track_id": "1MLr9b1fOybO3MGiLy47Ys",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "3PG6V5yuFfo4APiovOQoRv",
+    "release_date": "2022-04-08"
+  },
+  {
+    "track_id": "3RE5nHIVkC4KcA7snFaTKd",
+    "release_date": "2022-10-21"
+  },
+  {
+    "track_id": "068qo0w1Ki0cjnFYOUhAm2",
+    "release_date": "2021-01-15"
+  },
+  {
+    "track_id": "0gVbkmFqq5fIkXtJJ3UTfM",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "1esE8j1nVyzEQ5rVhYXoJT",
+    "release_date": "2019-05-10"
+  },
+  {
+    "track_id": "2PIlBukQ6limukVR8Ubb5o",
+    "release_date": "2013-05-13"
+  },
+  {
+    "track_id": "00DuOxungwHwVUX2m37P0P",
+    "release_date": "2020-05-08"
+  },
+  {
+    "track_id": "5aDpULK8MbJmHl42kR5KNI",
+    "release_date": "2003"
+  },
+  {
+    "track_id": "0fzCtVM9D5UEwiLqcY8Ouq",
+    "release_date": "2007-09-18"
+  },
+  {
+    "track_id": "34dnNAUoIPcwnK0RtVMBWZ",
+    "release_date": "2013-07-19"
+  },
+  {
+    "track_id": "08MFgEQeVLF37EyZ7jcwLc",
+    "release_date": "2021-12-06"
+  },
+  {
+    "track_id": "3us8sod4dLbM9FiMiPiEY8",
+    "release_date": "2014-10-07"
+  },
+  {
+    "track_id": "3e5yu9MkIvQx17mm7LF6KY",
+    "release_date": "2016-09-09"
+  },
+  {
+    "track_id": "14vExHBkh1prEAN94wZug8",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "3322ArxAq7wCSZI4fF77Q0",
+    "release_date": "2022-10-21"
+  },
+  {
+    "track_id": "16dkWKIlBsfYTISCVuDs0w",
+    "release_date": "2011-04-07"
+  },
+  {
+    "track_id": "5vjLSffimiIP26QG5WcN2K",
+    "release_date": "2017-02-03"
+  },
+  {
+    "track_id": "0X9MxHR1rTkEHDjp95F2OO",
+    "release_date": "2018-12-14"
+  },
+  {
+    "track_id": "6xKeQgzfjixSUld14qUezm",
+    "release_date": "2020-07-09"
+  },
+  {
+    "track_id": "4ptDJbJl35d7gQfeNteBwp",
+    "release_date": "2018-06-15"
+  },
+  {
+    "track_id": "2D4BSm5Z8Hq5zYbSgJwEOh",
+    "release_date": "2015-11-06"
+  },
+  {
+    "track_id": "6JGjevTaqr9J1xp7YvYUKF",
+    "release_date": "2022-10-21"
+  },
+  {
+    "track_id": "0Zf1BPkkFAWGtVHeBwHHz4",
+    "release_date": "2016-08-26"
+  },
+  {
+    "track_id": "3ax0rfGb7exLtl02LL08U9",
+    "release_date": "2022-10-07"
+  },
+  {
+    "track_id": "0wbmIfvndFV9VDvuUY1pYN",
+    "release_date": "2019-04-19"
+  },
+  {
+    "track_id": "1uSuY2qLCbx1QB7oPUVhFG",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "6twvFrIoIINH8UW8EB8OnU",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "73oHkllHIT8fdbzpxiXW40",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "0xbMRcMFqxJq1Wa7tvWPtn",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "6sp6Vx3sv2l5qxPfbQkcyt",
+    "release_date": "2022-10-12"
+  },
+  {
+    "track_id": "4LbWtBkN82ZRhz9jqzgrb3",
+    "release_date": "2017-05-19"
+  },
+  {
+    "track_id": "7Af2YlwMZryKOQiRfwMsD2",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "1fI1TMpz7FVkpoYBhmiywp",
+    "release_date": "2022-05-13"
+  },
+  {
+    "track_id": "1ae8XfBQ3fDEvmBjFaemGV",
+    "release_date": "2022-10-21"
+  },
+  {
+    "track_id": "6nXIYClvJAfi6ujLiKqEq8",
+    "release_date": "2012-02-28"
+  },
+  {
+    "track_id": "2SkJKMfjpYsNv0KWOxiegX",
+    "release_date": "2015-11-13"
+  },
+  {
+    "track_id": "4MihgVRpD82EZoT61GW63w",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "1BECZPXBXzobsfmlzj0g3I",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "0VhZ5JYfqPojSYeGWnk4dL",
+    "release_date": "2018-09-03"
+  },
+  {
+    "track_id": "38YgZVHPWOWsKrsCXz6JyP",
+    "release_date": "2007-01-01"
+  },
+  {
+    "track_id": "2lxBZVbkiCXC1soks2RXwV",
+    "release_date": "2018-06-22"
+  },
+  {
+    "track_id": "7cPuE0M35EajWPRO3nRcH8",
+    "release_date": "2022-10-07"
+  },
+  {
+    "track_id": "4VbDTk82rqWqVgoQC93CkC",
+    "release_date": "2018-10-12"
+  },
+  {
+    "track_id": "1EzrEOXmMH3G43AXT1y7pA",
+    "release_date": "2008-05-12"
+  },
+  {
+    "track_id": "3bHhUEOTIbezeZ856R0BX5",
+    "release_date": "2007-09-18"
+  },
+  {
+    "track_id": "04JS6OitE9VGsIS3S94Osg",
+    "release_date": "2022-10-18"
+  },
+  {
+    "track_id": "0e5PAxSyZ5DWWVqKANHETz",
+    "release_date": "2022-10-07"
+  },
+  {
+    "track_id": "7njTGO45SkaBTNu35t2Yq0",
+    "release_date": "2019-05-29"
+  },
+  {
+    "track_id": "7BXW1QCg56yzEBV8pW8pah",
+    "release_date": "2018-08-10"
+  },
+  {
+    "track_id": "0IktbUcnAGrvD03AWnz3Q8",
+    "release_date": "2008-05-12"
+  },
+  {
+    "track_id": "3Et4LKZLnXygPYfNdeB3D3",
+    "release_date": "2017-08-25"
+  },
+  {
+    "track_id": "6ta5yavnnEfCE4faU0jebM",
+    "release_date": "2006"
+  },
+  {
+    "track_id": "5rwq6R0Uq0BngM3rdmCeNg",
+    "release_date": "2003-11-04"
+  },
+  {
+    "track_id": "2nef44o0sjJDKB1ta4S0ub",
+    "release_date": "2022-10-20"
+  },
+  {
+    "track_id": "3tjjCCdXSdaVEo4q4y071G",
+    "release_date": "2020-01-31"
+  },
+  {
+    "track_id": "73CbJykoV6WapWGfTeRzTl",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "4mzP5mHkRvGxdhdGdAH7EJ",
+    "release_date": "2021-10-15"
+  },
+  {
+    "track_id": "0ZwdH0m32I8odedwvspYTh",
+    "release_date": "2017-04-24"
+  },
+  {
+    "track_id": "3lvo0I8c2qBJDLZWqExDgC",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "2pelUnMKr07JjJpilj9Yew",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "7bhHLZxkRekrNPPkEdDTbn",
+    "release_date": "2017-02-07"
+  },
+  {
+    "track_id": "6XrNrp7UtGgyZcHJ0ckL0w",
+    "release_date": "2019-04-05"
+  },
+  {
+    "track_id": "6Vc5wAMmXdKIAM7WUoEb7N",
+    "release_date": "2014-01-20"
+  },
+  {
+    "track_id": "6owKuyHxUqidcAA6fPKSyy",
+    "release_date": "2015-04-28"
+  },
+  {
+    "track_id": "3ixLIO5BsTmic0Pp27FaPY",
+    "release_date": "2022-10-14"
+  },
+  {
+    "track_id": "2qLMf6TuEC3ruGJg4SMMN6",
+    "release_date": "2008-05-01"
+  },
+  {
+    "track_id": "6Cvti10W0AzmzG9D1tpuKp",
+    "release_date": "2022-05-13"
+  },
+  {
+    "track_id": "27gHtbsHClwimHFtKgFop4",
+    "release_date": "2022-10-21"
+  },
+  {
+    "track_id": "1m5LC29RE52Bxy7hxvpOlL",
+    "release_date": "2022-10-20"
+  },
+  {
+    "track_id": "7x4b0UccXSKBWxWmjcrG2T",
+    "release_date": "2015-11-13"
+  },
+  {
+    "track_id": "7LwGBxB0h0CVmkOZxYKn0g",
+    "release_date": "2010-05-21"
+  },
+  {
+    "track_id": "7BRCa8MPiyuvr2VU3O9W0F",
+    "release_date": "2012-05-15"
+  },
+  {
+    "track_id": "3Vnes7v746dYzBn0FJTZ1W",
+    "release_date": "2022-10-21"
+  },
+  {
+    "track_id": "01MVOl9KtVTNfFiBU9I7dc",
+    "release_date": "2018-04-20"
+  },
+  {
+    "track_id": "03yc0G2OoH1Eeyu7Piy8fK",
+    "release_date": "2008-02-12"
+  },
+  {
+    "track_id": "38jy6kRlPt8z1GUS9WXeNh",
+    "release_date": "2012-04-13"
+  },
+  {
+    "track_id": "05pKAafT85jeeNhZ6kq7HT",
+    "release_date": "2012-01-03"
+  },
+  {
+    "track_id": "6gijbGNDNNJgT60Aj7UCyc",
+    "release_date": "2016-01-15"
+  },
+  {
+    "track_id": "2WZyfujzMweFLnozyUJBkW",
+    "release_date": "2005"
+  },
+  {
+    "track_id": "3H36x7buZdQD4687VmFrwY",
+    "release_date": "2022-10-14"
+  }
+]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,48 +1,16 @@
 import React from 'react';
-
-interface Plot {
-  filename: string;
-  title: string;
-  description?: string;
-}
-
-const plots: Plot[] = [
-  {
-    filename: 'plots/plot1.png',
-    title: 'First Plot',
-    description: 'Description of first plot'
-  },
-  {
-    filename: 'plots/plot2.png',
-    title: 'Second Plot',
-    description: 'Description of second plot'
-  }
-];
+import {BrowserRouter, Route, Router, Routes} from "react-router-dom";
+import ApiResponses from "./api/ApiResponses";
+import Homepage from "./components/Homepage";
 
 const App: React.FC = () => {
   return (
-    <div className="container mx-auto p-4">
-      <h1 className="text-3xl font-bold mb-6">Data Visualization Dashboard</h1>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        helloworld
-        {plots.map((plot, index) => (
-          <div
-            key={index}
-            className="border rounded-lg p-4 shadow-md"
-          >
-            <h2 className="text-xl font-semibold mb-2">{plot.title}</h2>
-            <img
-              src={plot.filename}
-              alt={plot.title}
-              className="w-full h-auto rounded-md"
-            />
-            {plot.description && (
-              <p className="mt-2 text-gray-600">{plot.description}</p>
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Homepage/>}/>
+          <Route path="/api/ApiResponses" element={<ApiResponses/>}/>
+        </Routes>
+      </BrowserRouter>
   );
 };
 

--- a/frontend/src/api/ApiResponses.tsx
+++ b/frontend/src/api/ApiResponses.tsx
@@ -1,0 +1,217 @@
+import {Box, Button} from "@mui/material";
+import React, {useState} from "react";
+import {saveAs} from "file-saver";
+
+
+type TrackData = {
+    [key: string]: string
+}
+
+interface JoinData {
+    release_date: string;
+}
+
+interface Artist {
+    external_urls: {
+        spotify: string;
+    };
+    href: string;
+    id: string;
+    name: string;
+    type: string;
+    uri: string;
+}
+
+interface Album {
+    album_type: string;
+    total_tracks: number;
+    available_markets: string[];
+    external_urls: {
+        spotify: string;
+    };
+    href: string;
+    id: string;
+    images: {
+        url: string;
+        height: number;
+        width: number;
+    }[];
+    name: string;
+    release_date: string;  // Release date as a string (e.g., "1981-12")
+    release_date_precision: string;
+    restrictions: {
+        reason: string;
+    };
+    type: string;
+    uri: string;
+    artists: Artist[];
+}
+
+interface ExternalIds {
+    isrc: string;
+    ean: string;
+    upc: string;
+}
+
+interface Track {
+    album: Album;
+    artists: Artist[];
+    available_markets: string[];
+    disc_number: number;
+    duration_ms: number;
+    explicit: boolean;
+    external_ids: ExternalIds;
+    external_urls: {
+        spotify: string;
+    };
+    href: string;
+    id: string;
+    is_playable: boolean;
+    linked_from: object;
+    restrictions: {
+        reason: string;
+    };
+    name: string;
+    popularity: number;
+    preview_url: string;
+    track_number: number;
+    type: string;
+    uri: string;
+    is_local: boolean;
+}
+
+// Define the structure of your API response
+type SpotifyTrackResponse = Track;
+
+interface ReleaseDate {
+    track_id: string;   // Unique ID for each track
+    release_date: string; // Release date as a string (could be in ISO format like 'YYYY-MM-DD')
+}
+
+
+export default function ApiResponses() {
+    const [columnDataToSearch, setColumnData] = useState<TrackData[]>();
+    const [columnDataToJoin, setColumnDataToJoin] = useState<ReleaseDate[]>();
+    const getSpotifyAccessToken = async () => {
+        const clientId = "7ddcff6c2baf45c8854857f577f2c03f";
+        const clientSecret = "7be3bec474714a83b6ab29016ad6936c";
+
+        const encodedCredentials = btoa(`${clientId}:${clientSecret}`);
+
+        const response = await fetch('https://accounts.spotify.com/api/token', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Basic ${encodedCredentials}`,
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams({
+                grant_type: 'client_credentials',
+            }),
+        });
+
+        const data = await response.json();
+        if (!response.ok) {
+            throw new Error('Error fetching access token');
+        }
+
+        console.log("Access Token:", data.access_token); // Log to verify
+        return data.access_token;
+    };
+
+    const fetchTrackData = async () => {
+        try {
+            const response = await fetch(`/songs_data.json`);
+            if (!response.ok) {
+                console.error('Track not found')
+            }
+
+            const data = await response.json()
+            console.log(data)
+            return data
+        } catch (error) {
+            console.error('Error fetching data:', error)
+        }
+    }
+    const fetchTrackAPIData = async (accessToken: string, trackId: string): Promise<SpotifyTrackResponse | undefined> => {
+        try {
+            const response = await fetch(
+                `https://api.spotify.com/v1/tracks/${trackId}?market=US`,
+                {
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                    },
+                });
+            if (!response.ok) {
+                console.error('Track not found');
+                return undefined;
+            }
+
+            const data: SpotifyTrackResponse = await response.json();
+            console.log(data);
+            return data;
+        } catch (error) {
+            console.error('Error fetching data:', error);
+            return undefined;
+        }
+    };
+
+    const handleAPIClick = (acesssToken: string) => {
+        const loadedData = columnDataToSearch !== null ? columnDataToSearch : [];
+        const resultData: ReleaseDate[] = [];
+        if (loadedData) {
+            // 0-104 is what has been recorded so far
+            loadedData.slice(0, 104).map((track: TrackData) => {
+                fetchTrackAPIData(acesssToken, track['track_id']).then((result) => {
+                    if (result) {
+                        const resultDate = isolateDate(result as SpotifyTrackResponse);
+                        const trackId = track['track_id'];
+                        resultData.push({track_id: trackId, release_date: resultDate})
+                    }
+                });
+            })
+        }
+        setColumnDataToJoin(resultData)
+    }
+
+    const isolateDate = (result: SpotifyTrackResponse) => {
+        const track_date = result !== null ? result.album.release_date : "none"
+        console.log(track_date)
+        return track_date
+    }
+
+    const saveJSONFile = () => {
+        const jsonBlob = new Blob([JSON.stringify(columnDataToJoin, null, 2)], {type: 'application/json'});
+        saveAs(jsonBlob, 'release_dates_0_104.json'); // This will trigger a download
+    };
+
+    return (
+        <Box>
+            <Button
+                onClick={() => {
+                    fetchTrackData().then((result: any) => {
+                        setColumnData(result)
+                    })
+                }}
+            >
+                Call Track JSON data
+            </Button>
+            <Button
+                onClick={() => {
+                    getSpotifyAccessToken().then((result: any) => {
+                        handleAPIClick(result)
+                    })
+                }}
+            >
+                Call Api
+            </Button>
+            <Button
+                onClick={() => {
+                    saveJSONFile()
+                }}
+            >
+                Download JSON File of Release Dates
+            </Button>
+            Press the button and then open the console for corresponding data
+        </Box>
+    );
+};

--- a/frontend/src/components/Homepage.tsx
+++ b/frontend/src/components/Homepage.tsx
@@ -1,0 +1,55 @@
+import {Box} from "@mui/material";
+import PrimaryAppBar from "./PrimaryAppBar";
+import React from "react";
+
+interface Plot {
+  filename: string;
+  title: string;
+  description?: string;
+}
+
+const plots: Plot[] = [
+  {
+    filename: 'plots/plot1.png',
+    title: 'First Plot',
+    description: 'Description of first plot'
+  },
+  {
+    filename: 'plots/plot2.png',
+    title: 'Second Plot',
+    description: 'Description of second plot'
+  },
+  {
+    filename: 'plots/plot3.png',
+    title: 'Second Plot',
+    description: 'Description of second plot'
+  }
+];
+
+export default function Homepage() {
+    return (
+        <Box>
+            <PrimaryAppBar/>
+            <div className="container mx-auto p-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    {plots.map((plot, index) => (
+                        <div
+                            key={index}
+                            className="border rounded-lg p-4 shadow-md"
+                        >
+                            <h2 className="text-xl font-semibold mb-2">{plot.title}</h2>
+                            <img
+                                src={plot.filename}
+                                alt={plot.title}
+                                className="w-full h-auto rounded-md"
+                            />
+                            {plot.description && (
+                                <p className="mt-2 text-gray-600">{plot.description}</p>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </Box>
+    );
+};

--- a/frontend/src/components/PrimaryAppBar.tsx
+++ b/frontend/src/components/PrimaryAppBar.tsx
@@ -1,0 +1,151 @@
+import {AppBar, Badge, Box, IconButton, Menu, MenuItem, Toolbar, Typography} from "@mui/material";
+import React from "react";
+import {useNavigate, useNavigation} from "react-router-dom";
+
+const pages = ['API Responses']
+const settings = ['Profile', 'Account', 'Dashboard', 'Logout'];
+
+export default function PrimaryAppBar() {
+    const navigate = useNavigate();
+    const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+    const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(null);
+
+    const [mobileMoreAnchorEl, setMobileMoreAnchorEl] =
+        React.useState<null | HTMLElement>(null);
+
+    const isMenuOpen = Boolean(anchorEl);
+    const isMobileMenuOpen = Boolean(mobileMoreAnchorEl);
+
+    const handleProfileMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleMobileMenuClose = () => {
+        setMobileMoreAnchorEl(null);
+    };
+
+    const handleCloseNavMenu = () => {
+        setAnchorElNav(null);
+    };
+
+    const handleMenuClose = () => {
+        setAnchorEl(null);
+        handleMobileMenuClose();
+    };
+
+    const handleMobileMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+        setMobileMoreAnchorEl(event.currentTarget);
+    };
+
+    const handlePageClick = (page: string) => {
+        if (page === 'API Responses') {
+            navigate('/api/ApiResponses')
+        }
+        handleCloseNavMenu()
+    }
+
+    const menuId = 'primary-search-account-menu';
+    const renderMenu = (
+        <Menu
+            anchorEl={anchorEl}
+            anchorOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+            }}
+            id={menuId}
+            keepMounted
+            transformOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+            }}
+            open={isMenuOpen}
+            onClose={handleMenuClose}
+        >
+            {settings.map((setting) => (
+                <MenuItem onClick={handleMenuClose} sx={{
+                    fontFamily: "inherit",
+                }}>{setting}</MenuItem>
+            ))}
+        </Menu>
+    );
+
+    const mobileMenuId = 'primary-search-account-menu-mobile';
+    const renderMobileMenu = (
+        <Menu
+            anchorEl={mobileMoreAnchorEl}
+            anchorOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+            }}
+            id={mobileMenuId}
+            keepMounted
+            transformOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+            }}
+            open={isMobileMenuOpen}
+            onClose={handleMobileMenuClose}
+        >
+            <MenuItem>
+                <IconButton size="large" aria-label="show 4 new mails" color="inherit">
+                </IconButton>
+                <p>Messages</p>
+            </MenuItem>
+            <MenuItem>
+                <IconButton
+                    size="large"
+                    aria-label="show 17 new notifications"
+                    color="inherit"
+                >
+                </IconButton>
+                <p>Notifications</p>
+            </MenuItem>
+            <MenuItem onClick={handleProfileMenuOpen}>
+                <IconButton
+                    size="large"
+                    aria-label="account of current user"
+                    aria-controls="primary-search-account-menu"
+                    aria-haspopup="true"
+                    color="inherit"
+                >
+                </IconButton>
+                <p>Profile</p>
+            </MenuItem>
+        </Menu>
+    );
+
+    return (
+        <Box sx={{flexGrow: 1}}>
+            <AppBar position="static">
+                <Toolbar>
+                    <IconButton
+                        size="large"
+                        edge="start"
+                        color="inherit"
+                        aria-label="open drawer"
+                        sx={{mr: 2}}
+                    >
+                    </IconButton>
+                    <Box sx={{ display: "flex", justifyContent: "center"}}>
+                        <Typography
+                            variant="h6"
+                            noWrap
+                            component="div"
+                            sx={{display: {xs: 'none', sm: 'block'}}}
+                        >
+                            DS 4200 Visualization Project
+                        </Typography>
+                    </Box>
+                    <Box sx={{flexGrow: 1}}/>
+                    {pages.map((page) => (
+                        <MenuItem key={page} onClick={() => handlePageClick(page)}>
+                            <Typography sx={{textAlign: 'center'}}>{page}</Typography>
+                        </MenuItem>
+                    ))}
+                </Toolbar>
+            </AppBar>
+            {renderMobileMenu}
+            {renderMenu}
+        </Box>
+    );
+}


### PR DESCRIPTION
Main things I did:
- set up Spotify API 
- started a homescreen in React 
- used the api to query for track release dates as a potential new column 
- generated JSON results to be joined back to the dataset if need be

Set up infrastructure in case we ever wanted to use the API to query about information we don't already have. I also made the frontend a little bit prettier using materialUI. I was able to query for about 104 tracks and get their release dates which were put into a JSON file that can be parsed back into python and joined on the original dataframe. 